### PR TITLE
Improved handling of white channels

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -7,6 +7,15 @@
     },
 
     "description": "An example Homebridge config for MagicHome.",
+    "option-description":[
+       "purewhite",
+           "controls the white channel for RGBW and RGBWW (ww - only) via brightness if white color is chosen,",
+           "values for white will be preserved if color is changed - other options will disable this one",
+       "onlywhite",
+           "only the white channels are used in RGBW or RGBWW - RGBWW: Color temperature is controlled for ww and cw balance",
+       "combinedwhite",
+           "additionally to the rgb channels, the white channels are controlled by brightness (RGBWW, both at the same level)"
+    ],
 
     "accessories": [
        {
@@ -14,7 +23,9 @@
            "name": "LED Strip",
            "ip": "192.168.1.111",
            "setup": "RGBWW",
-           "purewhite": true
+           "purewhite": false,
+           "onlywhite": false,
+           "combinedwhite": true
        }
     ]
 }


### PR DESCRIPTION
## Features

- Added an option to control the white channels in combination with the rgb values
- Added an option to use only the white channels (and control color temperatue on rgbww devices) not yet using color-temperature characteristic of hap

A description of the options can be found in the sample configuration file (right below the plugin description - I assume this is the best place for the documentation). If the new options are not enabled, the plugin should behave as the previous version.


## Solved issues
fixes #27: Use option ```combinedwhite=true``` see sample config for an example.
fixes #15, fixes #12: There are several methods to control the white channels now. See sample config for an example.
fixes #4: Use option ```onlywhite=true``` this will enable color temperature on RGBWW devices, but the color LEDs are permanently turned of. The RGB selection will still be available, as the change does not implement the color temperature characteristic